### PR TITLE
Implement category mapping and update AIEcommerce API key handling

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -318,7 +318,7 @@ docker compose up --build
 | `POSTGRES_DB`                | `orchestrator`                         | db             | PostgreSQL database name                   |
 | `DATABASE_URL`               | `postgresql+asyncpg://...@db:5432/...` | api, sentinel  | SQLAlchemy async connection string         |
 | `AIECOMMERCE_API_URL`        | `https://api.aiecommerce.example.com`  | api, sentinel  | Base URL for the aiecommerce REST API      |
-| `AIECOMMERCE_API_KEY`        | _(empty)_                              | api, sentinel  | Bearer token for aiecommerce API           |
+| `AIECOMMERCE_API_KEY`        | _(empty)_                              | api, sentinel  | API key for aiecommerce API (sent as X-API-Key header) |
 | `MERCADOLIBRE_CLIENT_ID`     | _(empty)_                              | api            | MercadoLibre OAuth2 client ID              |
 | `MERCADOLIBRE_CLIENT_SECRET` | _(empty)_                              | api            | MercadoLibre OAuth2 client secret          |
 | `MERCADOLIBRE_REDIRECT_URI`  | `https://localhost:8000/auth/callback` | api            | MercadoLibre OAuth2 redirect URI           |

--- a/src/orchestrator/graph/nodes/bundle_creator.py
+++ b/src/orchestrator/graph/nodes/bundle_creator.py
@@ -87,7 +87,7 @@ async def bundle_creator_node(state: GraphState) -> dict[str, object]:
     for cat in _PERIPHERAL_CATEGORIES:
         try:
             response = await api_client.list_products(
-                category=cat.value,
+                category=cat,
                 active_only=True,
                 has_stock=True,
             )

--- a/src/orchestrator/graph/nodes/inventory_architect.py
+++ b/src/orchestrator/graph/nodes/inventory_architect.py
@@ -107,7 +107,7 @@ async def inventory_architect_node(state: GraphState) -> dict[str, object]:
     for cat in _INVENTORY_CATEGORIES:
         try:
             response = await api_client.list_products(
-                category=cat.value,
+                category=cat,
                 active_only=True,
                 has_stock=True,
             )

--- a/src/orchestrator/schemas/category_mapping.py
+++ b/src/orchestrator/schemas/category_mapping.py
@@ -1,0 +1,89 @@
+"""Mapping between internal component categories and aiecommerce API category strings.
+
+The external aiecommerce API uses Spanish-language category names
+(e.g. ``"PROCESADORES"``, ``"MOTHER BOARDS"``) that differ from the
+internal ``ComponentCategory`` enum values (``"cpu"``, ``"motherboard"``).
+
+This module provides a single-responsibility translation layer so the
+rest of the codebase can work with clean, English-only enum values
+while the API client sends/receives the correct external strings.
+"""
+
+from orchestrator.schemas.product import ComponentCategory
+
+# ---------------------------------------------------------------------------
+# Internal → API mapping
+# ---------------------------------------------------------------------------
+
+COMPONENT_TO_API: dict[ComponentCategory, str] = {
+    ComponentCategory.CPU: "PROCESADORES",
+    ComponentCategory.MOTHERBOARD: "MOTHER BOARDS",
+    ComponentCategory.RAM: "MEMORIA RAM",
+    ComponentCategory.GPU: "TARJETA DE VIDEO",
+    ComponentCategory.SSD: "UNIDADES DE ESTADO SOLIDO Y DISCOS DUROS",
+    ComponentCategory.PSU: "FUENTES DE PODER",
+    ComponentCategory.CASE: "CASE",
+    ComponentCategory.FAN: "ACCESORIOS",
+    ComponentCategory.KEYBOARD: "TECLADOS",
+    ComponentCategory.MOUSE: "MOUSE",
+    ComponentCategory.MONITOR: "MONITORES Y TELEVISORES",
+    ComponentCategory.SPEAKERS: "PARLANTES",
+}
+
+# ---------------------------------------------------------------------------
+# API → Internal mapping (reverse look-up)
+# ---------------------------------------------------------------------------
+
+API_TO_COMPONENT: dict[str, ComponentCategory] = {v: k for k, v in COMPONENT_TO_API.items()}
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def to_api_category(category: ComponentCategory) -> str:
+    """Translate an internal ``ComponentCategory`` to the aiecommerce API string.
+
+    Args:
+        category: Internal component category enum member.
+
+    Returns:
+        The corresponding aiecommerce API category string.
+
+    Raises:
+        ValueError: If the category has no known API mapping.
+    """
+    try:
+        return COMPONENT_TO_API[category]
+    except KeyError:
+        raise ValueError(
+            f"No API mapping for category '{category}'. "
+            f"Known categories: {', '.join(c.value for c in COMPONENT_TO_API)}"
+        ) from None
+
+
+def from_api_category(api_category: str) -> ComponentCategory:
+    """Translate an aiecommerce API category string to a ``ComponentCategory``.
+
+    The look-up is case-insensitive: the incoming string is normalized to
+    upper-case before matching against the API category keys.
+
+    Args:
+        api_category: Category string as returned by the aiecommerce API.
+
+    Returns:
+        The corresponding ``ComponentCategory`` enum member.
+
+    Raises:
+        ValueError: If the API string has no known internal mapping.
+    """
+    normalized = api_category.strip().upper()
+    result = API_TO_COMPONENT.get(normalized)
+    if result is not None:
+        return result
+
+    raise ValueError(
+        f"Unknown API category '{api_category}'. "
+        f"Known API categories: {', '.join(API_TO_COMPONENT)}"
+    ) from None

--- a/src/orchestrator/schemas/product.py
+++ b/src/orchestrator/schemas/product.py
@@ -1,8 +1,9 @@
 """Pydantic schemas for product API responses and tower build objects."""
 
 import enum
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ComponentCategory(enum.StrEnum):
@@ -37,6 +38,43 @@ class ComponentCategory(enum.StrEnum):
     SPEAKERS = "speakers"
 
 
+def _coerce_category(value: object) -> object:
+    """Coerce an API category string or internal value to a ``ComponentCategory``.
+
+    If *value* is already a ``ComponentCategory`` it is returned as-is.
+    If it is a string that matches an internal enum value (e.g. ``"cpu"``)
+    it passes through unchanged for Pydantic to convert.  Otherwise the
+    string is looked up in the API → internal reverse mapping.
+
+    Args:
+        value: Raw category value from incoming data.
+
+    Returns:
+        A value that Pydantic can convert to ``ComponentCategory``.
+    """
+    if isinstance(value, ComponentCategory):
+        return value
+
+    if isinstance(value, str):
+        # Fast path: value already matches an internal enum value.
+        try:
+            return ComponentCategory(value)
+        except ValueError:
+            pass
+
+        # Slow path: try the API → internal reverse mapping (lazy import
+        # to avoid a circular import at module level).
+        from orchestrator.schemas.category_mapping import from_api_category
+
+        try:
+            return from_api_category(value)
+        except ValueError:
+            pass
+
+    # Fall through — let Pydantic raise its own validation error.
+    return value
+
+
 class ProductListItem(BaseModel):
     """A single product from the aiecommerce product list.
 
@@ -65,6 +103,12 @@ class ProductListItem(BaseModel):
     last_bundled_date: str | None = None
     is_active: bool = True
     total_available_stock: int = 0
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def _normalise_category(cls, value: Any) -> Any:
+        """Accept both internal enum values and external API category strings."""
+        return _coerce_category(value)
 
 
 class ProductDetail(BaseModel):
@@ -106,6 +150,12 @@ class ProductDetail(BaseModel):
     image_url: str | None = None
     image_urls: list[dict[str, object]] = Field(default_factory=list)
     total_available_stock: int = 0
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def _normalise_category(cls, value: Any) -> Any:
+        """Accept both internal enum values and external API category strings."""
+        return _coerce_category(value)
 
 
 class ProductListResponse(BaseModel):

--- a/src/orchestrator/services/aiecommerce.py
+++ b/src/orchestrator/services/aiecommerce.py
@@ -11,7 +11,8 @@ import httpx
 
 from orchestrator.core.config import Settings
 from orchestrator.core.exceptions import APIClientError
-from orchestrator.schemas.product import ProductDetail, ProductListResponse
+from orchestrator.schemas.category_mapping import to_api_category
+from orchestrator.schemas.product import ComponentCategory, ProductDetail, ProductListResponse
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ class AIEcommerceClient:
 
     async def list_products(
         self,
-        category: str | None = None,
+        category: ComponentCategory | None = None,
         active_only: bool = True,
         has_stock: bool = True,
     ) -> ProductListResponse:
@@ -112,8 +113,10 @@ class AIEcommerceClient:
         to filter results by category, active status, and stock availability.
 
         Args:
-            category: Filter by component category (e.g. ``"cpu"``). When
-                ``None`` no category filter is applied.
+            category: Filter by component category. The internal enum value
+                is automatically translated to the API category string
+                (e.g. ``ComponentCategory.CPU`` → ``"PROCESADORES"``).
+                When ``None`` no category filter is applied.
             active_only: When ``True`` only active items are returned.
             has_stock: When ``True`` only items with stock > 0 are returned.
 
@@ -125,7 +128,7 @@ class AIEcommerceClient:
         """
         params: dict[str, str] = {}
         if category is not None:
-            params["category"] = category
+            params["category"] = to_api_category(category)
         if active_only:
             params["is_active"] = "true"
         if has_stock:

--- a/src/orchestrator/services/aiecommerce.py
+++ b/src/orchestrator/services/aiecommerce.py
@@ -30,7 +30,7 @@ class AIEcommerceClient:
     def __init__(self, settings: Settings) -> None:
         self._base_url = settings.AIECOMMERCE_API_URL
         self._headers = {
-            "Authorization": f"Bearer {settings.AIECOMMERCE_API_KEY}",
+            "X-API-Key": settings.AIECOMMERCE_API_KEY,
             "Content-Type": "application/json",
         }
 

--- a/tests/test_schemas/test_category_mapping.py
+++ b/tests/test_schemas/test_category_mapping.py
@@ -1,0 +1,114 @@
+"""Tests for the category mapping module.
+
+Validates the bidirectional mapping between internal ``ComponentCategory``
+enum values and the external aiecommerce API category strings.
+"""
+
+import pytest
+
+from orchestrator.schemas.category_mapping import (
+    API_TO_COMPONENT,
+    COMPONENT_TO_API,
+    from_api_category,
+    to_api_category,
+)
+from orchestrator.schemas.product import ComponentCategory
+
+# ---------------------------------------------------------------------------
+# Completeness
+# ---------------------------------------------------------------------------
+
+
+def test_every_component_category_has_api_mapping() -> None:
+    """Every ``ComponentCategory`` member must have an API mapping."""
+    for member in ComponentCategory:
+        assert member in COMPONENT_TO_API, f"Missing API mapping for {member!r}"
+
+
+def test_reverse_mapping_has_same_length() -> None:
+    """The reverse mapping must contain the same number of entries."""
+    assert len(API_TO_COMPONENT) == len(COMPONENT_TO_API)
+
+
+# ---------------------------------------------------------------------------
+# to_api_category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("internal", "expected_api"),
+    [
+        (ComponentCategory.CPU, "PROCESADORES"),
+        (ComponentCategory.MOTHERBOARD, "MOTHER BOARDS"),
+        (ComponentCategory.RAM, "MEMORIA RAM"),
+        (ComponentCategory.GPU, "TARJETA DE VIDEO"),
+        (ComponentCategory.SSD, "UNIDADES DE ESTADO SOLIDO Y DISCOS DUROS"),
+        (ComponentCategory.PSU, "FUENTES DE PODER"),
+        (ComponentCategory.CASE, "CASE"),
+        (ComponentCategory.FAN, "ACCESORIOS"),
+        (ComponentCategory.KEYBOARD, "TECLADOS"),
+        (ComponentCategory.MOUSE, "MOUSE"),
+        (ComponentCategory.MONITOR, "MONITORES Y TELEVISORES"),
+        (ComponentCategory.SPEAKERS, "PARLANTES"),
+    ],
+)
+def test_to_api_category(internal: ComponentCategory, expected_api: str) -> None:
+    """``to_api_category`` returns the correct API string for each category."""
+    assert to_api_category(internal) == expected_api
+
+
+# ---------------------------------------------------------------------------
+# from_api_category
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("api_string", "expected_internal"),
+    [
+        ("PROCESADORES", ComponentCategory.CPU),
+        ("MOTHER BOARDS", ComponentCategory.MOTHERBOARD),
+        ("MEMORIA RAM", ComponentCategory.RAM),
+        ("TARJETA DE VIDEO", ComponentCategory.GPU),
+        ("UNIDADES DE ESTADO SOLIDO Y DISCOS DUROS", ComponentCategory.SSD),
+        ("FUENTES DE PODER", ComponentCategory.PSU),
+        ("CASE", ComponentCategory.CASE),
+        ("ACCESORIOS", ComponentCategory.FAN),
+        ("TECLADOS", ComponentCategory.KEYBOARD),
+        ("MOUSE", ComponentCategory.MOUSE),
+        ("MONITORES Y TELEVISORES", ComponentCategory.MONITOR),
+        ("PARLANTES", ComponentCategory.SPEAKERS),
+    ],
+)
+def test_from_api_category(api_string: str, expected_internal: ComponentCategory) -> None:
+    """``from_api_category`` returns the correct internal enum for each API string."""
+    assert from_api_category(api_string) == expected_internal
+
+
+def test_from_api_category_case_insensitive() -> None:
+    """``from_api_category`` is case-insensitive."""
+    assert from_api_category("procesadores") == ComponentCategory.CPU
+    assert from_api_category("Mother Boards") == ComponentCategory.MOTHERBOARD
+    assert from_api_category("memoria ram") == ComponentCategory.RAM
+
+
+def test_from_api_category_strips_whitespace() -> None:
+    """``from_api_category`` strips leading/trailing whitespace."""
+    assert from_api_category("  PROCESADORES  ") == ComponentCategory.CPU
+
+
+def test_from_api_category_unknown_raises() -> None:
+    """``from_api_category`` raises ``ValueError`` for unknown API strings."""
+    with pytest.raises(ValueError, match="Unknown API category"):
+        from_api_category("UNKNOWN_CATEGORY")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category", list(ComponentCategory))
+def test_round_trip(category: ComponentCategory) -> None:
+    """Converting to API and back must return the original category."""
+    api_string = to_api_category(category)
+    assert from_api_category(api_string) == category

--- a/tests/test_schemas/test_product.py
+++ b/tests/test_schemas/test_product.py
@@ -135,6 +135,33 @@ def test_product_list_item_invalid_category() -> None:
         ProductListItem(**bad)
 
 
+def test_product_list_item_accepts_api_category_string() -> None:
+    """ProductListItem accepts external API category strings (e.g. 'PROCESADORES')."""
+    data = {**VALID_ITEM_DATA, "category": "PROCESADORES"}
+    item = ProductListItem(**data)
+    assert item.category == ComponentCategory.CPU
+
+
+def test_product_detail_accepts_api_category_string() -> None:
+    """ProductDetail accepts external API category strings."""
+    detail = ProductDetail(
+        id=1,
+        code="PROD-001",
+        sku="MB-001",
+        normalized_name="ASUS ROG",
+        price=299.99,
+        category="MOTHER BOARDS",
+    )
+    assert detail.category == ComponentCategory.MOTHERBOARD
+
+
+def test_product_list_item_accepts_api_category_case_insensitive() -> None:
+    """API category strings are accepted regardless of case."""
+    data = {**VALID_ITEM_DATA, "category": "procesadores"}
+    item = ProductListItem(**data)
+    assert item.category == ComponentCategory.CPU
+
+
 # ---------------------------------------------------------------------------
 # ProductDetail
 # ---------------------------------------------------------------------------

--- a/tests/test_services/test_aiecommerce.py
+++ b/tests/test_services/test_aiecommerce.py
@@ -7,7 +7,12 @@ import pytest
 
 from orchestrator.core.config import Settings
 from orchestrator.core.exceptions import APIClientError
-from orchestrator.schemas.product import ProductDetail, ProductListItem, ProductListResponse
+from orchestrator.schemas.product import (
+    ComponentCategory,
+    ProductDetail,
+    ProductListItem,
+    ProductListResponse,
+)
 from orchestrator.services.aiecommerce import _BACKOFF_BASE, _MAX_RETRIES, AIEcommerceClient
 
 # ---------------------------------------------------------------------------
@@ -97,7 +102,7 @@ class TestListProducts:
 
     @pytest.mark.asyncio
     async def test_list_products_with_category_filter(self, client: AIEcommerceClient) -> None:
-        """Passes category as a query parameter when provided."""
+        """Passes the translated API category string as a query parameter."""
         mock_resp = _make_response(200, VALID_LIST_PAYLOAD)
         mock_get = AsyncMock(return_value=mock_resp)
 
@@ -107,11 +112,11 @@ class TestListProducts:
             mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http)
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-            await client.list_products(category="cpu")
+            await client.list_products(category=ComponentCategory.CPU)
 
         _, call_kwargs = mock_get.call_args
         params = call_kwargs.get("params", {})
-        assert params.get("category") == "cpu"
+        assert params.get("category") == "PROCESADORES"
 
     @pytest.mark.asyncio
     async def test_list_products_active_and_stock_filters(self, client: AIEcommerceClient) -> None:


### PR DESCRIPTION
Introduce category mapping for product handling to support external API category strings. Update the AIEcommerce API key header to use `X-API-Key` instead of a Bearer token.